### PR TITLE
Fix SurroundRenderer init to allow play script to run

### DIFF
--- a/src/jaxatari/games/jax_surround.py
+++ b/src/jaxatari/games/jax_surround.py
@@ -44,7 +44,8 @@ class SurroundInfo(NamedTuple):
 class SurroundRenderer(JAXGameRenderer):
     """Very small dummy renderer used for tests."""
 
-    def __init__(self, consts: SurroundConstants):
+    def __init__(self, consts: Optional[SurroundConstants] = None):
+        consts = consts or SurroundConstants()
         super().__init__(consts)
         self.consts = consts
 


### PR DESCRIPTION
## Summary
- initialize `SurroundRenderer` with optional constants
- running `scripts/play.py -g surround` now works