### PR TITLE
Add Surround visual design docs and update environment

### DIFF
--- a/docs/source/api/games/index.rst
+++ b/docs/source/api/games/index.rst
@@ -10,3 +10,4 @@ Object-centric environments for Atari games.
    kangaroo
    pong
    seaquest
+   surround

--- a/docs/source/api/games/surround.rst
+++ b/docs/source/api/games/surround.rst
@@ -1,0 +1,17 @@
+Surround Environment
+====================
+
+.. automodule:: jaxatari.games.jax_surround
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Visual Design Notes
+-------------------
+
+- **Playfield size:** logical grid of 40×24 cells.
+- **Cell dimensions:** each cell is 4×8 pixels, giving a 160×192 gameplay area on a 210×160 screen.
+- **Background color:** solid color that can vary per mode.
+- **Trail colors:** each player uses a distinct trail color (green for player 1, purple for player 2 by default).
+- **Moving block:** head uses the same size as a trail segment and can highlight the current position.
+- **Visual simplicity:** empty background that gradually fills with colored trail squares.


### PR DESCRIPTION
## Summary
- document Surround game visuals
- expand Surround grid to 40x24 with cell size info
- add player trail colors and background color handling
- update action space and rendering logic
- keep single-scalar rewards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dff51b7548332b389acdcbb9a394f