### PR TITLE
Implement new Surround state representation

### DIFF
--- a/docs/source/api/games/surround.rst
+++ b/docs/source/api/games/surround.rst
@@ -15,3 +15,6 @@ Visual Design Notes
 - **Trail colors:** each player uses a distinct trail color (green for player 1, purple for player 2 by default).
 - **Moving block:** head uses the same size as a trail segment and can highlight the current position.
 - **Visual simplicity:** empty background that gradually fills with colored trail squares.
+ - **State representation:** single grid of 40×24 with values ``0`` for empty,
+   ``1`` for player 0 trails and ``2`` for player 1 trails. The moving heads are
+   tracked separately via ``pos0``/``pos1`` and ``dir0``/``dir1``.

--- a/tests/test_surround_rules.py
+++ b/tests/test_surround_rules.py
@@ -7,8 +7,8 @@ from jaxatari.environment import JAXAtariAction as Action
 def test_surround_start_positions():
     env = jaxatari.make("surround")
     _obs, state = env.reset()
-    assert tuple(state.p1_pos.tolist()) == env.consts.P1_START_POS
-    assert tuple(state.p2_pos.tolist()) == env.consts.P2_START_POS
+    assert tuple(state.pos0.tolist()) == env.consts.P1_START_POS
+    assert tuple(state.pos1.tolist()) == env.consts.P2_START_POS
 
 
 def test_surround_crossing_no_crash():
@@ -31,5 +31,5 @@ def test_surround_wall_crash():
         if done:
             break
     assert bool(done)
-    assert state.p2_score == 1
+    assert state.score1 == 1
     assert reward == -1.0


### PR DESCRIPTION
## Summary
- extend `SurroundConstants` with starting directions and reverse rules
- rework `SurroundState` to hold positions, directions and single trail grid
- adjust step logic for directional movement and trail updates
- update docs and tests for new state fields

## Testing
- `pytest tests/test_surround_rules.py::test_surround_start_positions -q`
- `pytest -q` *(fails: DependencyNotInstalled: opencv, ModuleNotFoundError: pygame, AssertionError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e1392dff48332b81ad03c16e32b7a